### PR TITLE
Feature: Notification URL

### DIFF
--- a/src/push/index.js
+++ b/src/push/index.js
@@ -69,7 +69,7 @@ function init(app, db, awaiting_moderation) {
                 const cnt = bySlug[k],
                     msg = {
                         message: `${cnt} new comment${cnt>1?'s':''} on "${k}" are awaiting moderation.`,
-                        url: `/${k}`,
+                        url: config.get('page_url').replace('%SLUG%', k),
                         sound: !!row.active ? 'pushover' : 'none'
                     };
                 delete bySlug[k];


### PR DESCRIPTION
Currently with Pushover and Webpush only the slug is being sent as the URL. This drops the slug into the `page_url` config value and causes a full URL to be sent.