### PR TITLE
Code block fix

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -52,25 +52,12 @@ renderer.code = function(code, language, escaped) {
   }
 
   if (!lang) {
-    return '<pre><code>'
-      + (escaped ? code : escape(code, true))
-      + '</code></pre>';
+    return `<pre><code>${code}</code></pre>`;
   }
 
   lang = lang.replace(escapeReplace, function (ch) { return escapeReplacements[ch]; });
 
-  const finalCode = '<pre class="'
-    + this.options.langPrefix
-    + lang
-    + '"><code class="'
-    + this.options.langPrefix
-    + lang
-    + '">'
-    + code
-    + '</code></pre>\n';
-
-  console.log(finalCode);
-  return finalCode;
+  return `<pre class="${this.options.langPrefix}${lang}"><code class="${this.options.langPrefix}${lang}">${code}</code></pre>`;
 }
 
 marked.setOptions({ sanitize: true, langPrefix: "language-", renderer: renderer });

--- a/src/server.js
+++ b/src/server.js
@@ -27,6 +27,17 @@ const awaiting_moderation = [];
 
 var renderer = new marked.Renderer();
 renderer.code = function(code, language, escaped) {
+  // escaping helpers
+  var escapeReplace = /[&<>"']/g
+  var escapeReplacements = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+
+
   var lang = (language || '').match(/\S*/)[0];
   if (this.options.highlight) {
     var out = this.options.highlight(code, lang);
@@ -36,21 +47,30 @@ renderer.code = function(code, language, escaped) {
     }
   }
 
+  if(!escaped) {
+    code = code.replace(escapeReplace, function (ch) { return escapeReplacements[ch]; });
+  }
+
   if (!lang) {
     return '<pre><code>'
       + (escaped ? code : escape(code, true))
       + '</code></pre>';
   }
 
-  return '<pre class="'
+  lang = lang.replace(escapeReplace, function (ch) { return escapeReplacements[ch]; });
+
+  const finalCode = '<pre class="'
     + this.options.langPrefix
-    + escape(lang, true)
+    + lang
     + '"><code class="'
     + this.options.langPrefix
-    + escape(lang, true)
+    + lang
     + '">'
-    + (escaped ? code : escape(code, true))
+    + code
     + '</code></pre>\n';
+
+  console.log(finalCode);
+  return finalCode;
 }
 
 marked.setOptions({ sanitize: true, langPrefix: "language-", renderer: renderer });

--- a/src/server.js
+++ b/src/server.js
@@ -25,7 +25,35 @@ const config = require('./config');
 
 const awaiting_moderation = [];
 
-marked.setOptions({ sanitize: true });
+var renderer = new marked.Renderer();
+renderer.code = function(code, language, escaped) {
+  var lang = (language || '').match(/\S*/)[0];
+  if (this.options.highlight) {
+    var out = this.options.highlight(code, lang);
+    if (out != null && out !== code) {
+      escaped = true;
+      code = out;
+    }
+  }
+
+  if (!lang) {
+    return '<pre><code>'
+      + (escaped ? code : escape(code, true))
+      + '</code></pre>';
+  }
+
+  return '<pre class="'
+    + this.options.langPrefix
+    + escape(lang, true)
+    + '"><code class="'
+    + this.options.langPrefix
+    + escape(lang, true)
+    + '">'
+    + (escaped ? code : escape(code, true))
+    + '</code></pre>\n';
+}
+
+marked.setOptions({ sanitize: true, langPrefix: "language-", renderer: renderer });
 
 dbHandler
     .init()


### PR DESCRIPTION
Fixes #83 

This adds a custom renderer for marked.
The code is almost identical to the current implementation (you can view markedjs [code here ﻿﻿](https://github.com/markedjs/marked/blob/master/lib/marked.js#L931)).
The main part of this fix adds `class="language-lang"` to the code block's `<pre>` tag.

As I am using PrismJS for syntax highlighting on my website, this also allows code blocks to be picked up by the PrismJS CSS and highlighted properly.